### PR TITLE
feat: add player search endpoint

### DIFF
--- a/backend/internal/player/handler.go
+++ b/backend/internal/player/handler.go
@@ -16,8 +16,9 @@ func NewHandler(u Usecase) *Handler {
 }
 
 func (h *Handler) RegisterRoutes(r *gin.Engine) {
-	r.GET("/players/:name", h.getPlayerCard)
+	r.GET("/players/search", h.searchPlayers)
 	r.GET("/players", h.getAllPlayers)
+	r.GET("/players/:name", h.getPlayerCard)
 }
 
 func (h *Handler) getPlayerCard(c *gin.Context) {
@@ -42,5 +43,21 @@ func (h *Handler) getAllPlayers(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	c.JSON(http.StatusOK, players)
+}
+
+func (h *Handler) searchPlayers(c *gin.Context) {
+	name := c.Query("name")
+	if name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name query parameter is required"})
+		return
+	}
+
+	players, err := h.uc.SearchPlayers(name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
 	c.JSON(http.StatusOK, players)
 }

--- a/backend/internal/player/usecase.go
+++ b/backend/internal/player/usecase.go
@@ -3,6 +3,7 @@ package player
 type Usecase interface {
 	GetPlayerCardByName(name string) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
+	SearchPlayers(name string) ([]PlayerShort, error)
 }
 
 type usecase struct {
@@ -19,4 +20,8 @@ func (u *usecase) GetPlayerCardByName(name string) (*PlayerCard, error) {
 
 func (u *usecase) GetAllPlayers() ([]PlayerShort, error) {
 	return u.repo.GetAllPlayers()
+}
+
+func (u *usecase) SearchPlayers(name string) ([]PlayerShort, error) {
+	return u.repo.SearchPlayers(name)
 }


### PR DESCRIPTION
## Summary
- add repository, usecase, handler logic to search players by name substring
- expose GET /players/search endpoint returning matching player summaries

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a0572395c832a9532173132c9024f