### PR TITLE
Use season and league IDs for player stats

### DIFF
--- a/backend/internal/player/handler.go
+++ b/backend/internal/player/handler.go
@@ -2,7 +2,7 @@ package player
 
 import (
 	"net/http"
-	"net/url"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -18,18 +18,21 @@ func NewHandler(u Usecase) *Handler {
 func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	r.GET("/players/search", h.searchPlayers)
 	r.GET("/players", h.getAllPlayers)
-	r.GET("/players/:name", h.getPlayerCard)
+	r.GET("/players/:id", h.getPlayerCard)
 }
 
 func (h *Handler) getPlayerCard(c *gin.Context) {
-	encodedName := c.Param("name")
-	name, err := url.QueryUnescape(encodedName)
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid player name"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid player id"})
 		return
 	}
 
-	playerCard, err := h.uc.GetPlayerCardByName(name)
+	seasonID, _ := strconv.Atoi(c.DefaultQuery("season_id", "0"))
+	leagueID, _ := strconv.Atoi(c.DefaultQuery("league_id", "0"))
+
+	playerCard, err := h.uc.GetPlayerCardByID(id, seasonID, leagueID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "player not found"})
 		return

--- a/backend/internal/player/model.go
+++ b/backend/internal/player/model.go
@@ -1,17 +1,14 @@
 package player
 
 type Stats struct {
-	Games       int `json:"games"`
-	Wins        int `json:"wins"`
-	Losses      int `json:"losses"`
 	Goals       int `json:"goals"`
 	Assists     int `json:"assists"`
-	Penalties   int `json:"penalties"`
 	YellowCards int `json:"yellow_cards"`
 	RedCards    int `json:"red_cards"`
 }
 
 type PlayerCard struct {
+	ID        int    `json:"id"`
 	FullName  string `json:"full_name"`
 	Position  string `json:"position"`
 	Photo_URL string `json:"photo_url"`
@@ -20,6 +17,7 @@ type PlayerCard struct {
 }
 
 type PlayerShort struct {
+	ID        int    `json:"id"`
 	FullName  string `json:"full_name"`
 	Position  string `json:"position"`
 	Photo_URL string `json:"photo_url"`

--- a/backend/internal/player/repository.go
+++ b/backend/internal/player/repository.go
@@ -5,7 +5,8 @@ import (
 )
 
 type Repository interface {
-	GetPlayerCardByName(name string) (*PlayerCard, error)
+	GetPlayerCardByID(id, seasonID, leagueID int) (*PlayerCard, error)
+	GetPlayerCardByName(name string, seasonID, leagueID int) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
 	SearchPlayers(name string) ([]PlayerShort, error)
 }
@@ -18,43 +19,34 @@ func NewRepository(db *sql.DB) Repository {
 	return &repository{db: db}
 }
 
-func (r *repository) GetPlayerCardByName(name string) (*PlayerCard, error) {
+// ===== Карточка игрока по ID =====
+func (r *repository) GetPlayerCardByID(id, seasonID, leagueID int) (*PlayerCard, error) {
 	query := `
-        SELECT 
-            p.full_name, 
-            p.position, 
-            p.photo_url,
-            t.name AS team_name,
-            COALESCE(SUM(ps.goals), 0),
-            COALESCE(SUM(ps.assists), 0),
-            COALESCE(SUM(ps.penalties), 0),
-            COALESCE(SUM(ps.yellow_cards), 0),
-            COALESCE(SUM(ps.red_cards), 0),
-            COUNT(DISTINCT mp.match_id),
-            COUNT(DISTINCT CASE WHEN m.home_team_id = pth.team_id AND m.home_score > m.away_score THEN m.id
-                                WHEN m.away_team_id = pth.team_id AND m.away_score > m.home_score THEN m.id
-                                ELSE NULL END),
-            COUNT(DISTINCT CASE WHEN m.home_team_id = pth.team_id AND m.home_score < m.away_score THEN m.id
-                                WHEN m.away_team_id = pth.team_id AND m.away_score < m.home_score THEN m.id
-                                ELSE NULL END)
-        FROM players p
-        JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
-        JOIN teams t ON t.id = pth.team_id
-        LEFT JOIN match_participation mp ON mp.player_id = p.id
-        LEFT JOIN matches m ON m.id = mp.match_id
-        LEFT JOIN player_stats ps ON ps.match_participation_id = mp.id
-        WHERE p.full_name = $1
-        GROUP BY p.full_name, p.position, p.photo_url, t.name
+    SELECT 
+        p.id,
+        p.full_name,
+        p.position,
+        p.photo_url,
+        t.name AS team_name,
+        COALESCE(v.total_goals, 0),
+        COALESCE(v.total_assists, 0),
+        COALESCE(v.total_yellow, 0),
+        COALESCE(v.total_red, 0)
+    FROM players p
+    JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
+    JOIN teams t ON t.id = pth.team_id
+    LEFT JOIN v_player_season_stats v 
+           ON v.player_id = p.id
+           AND v.season_id = $2
+           AND v.league_id = $3
+    WHERE p.id = $1;
     `
-
 	var card PlayerCard
 	var stats Stats
 
-	err := r.db.QueryRow(query, name).Scan(
-		&card.FullName, &card.Position, &card.Photo_URL, &card.Team,
-		&stats.Goals, &stats.Assists, &stats.Penalties,
-		&stats.YellowCards, &stats.RedCards,
-		&stats.Games, &stats.Wins, &stats.Losses,
+	err := r.db.QueryRow(query, id, seasonID, leagueID).Scan(
+		&card.ID, &card.FullName, &card.Position, &card.Photo_URL, &card.Team,
+		&stats.Goals, &stats.Assists, &stats.YellowCards, &stats.RedCards,
 	)
 	if err != nil {
 		return nil, err
@@ -64,16 +56,55 @@ func (r *repository) GetPlayerCardByName(name string) (*PlayerCard, error) {
 	return &card, nil
 }
 
+// ===== Карточка игрока по имени =====
+func (r *repository) GetPlayerCardByName(name string, seasonID, leagueID int) (*PlayerCard, error) {
+	query := `
+    SELECT 
+        p.id,
+        p.full_name,
+        p.position,
+        p.photo_url,
+        t.name AS team_name,
+        COALESCE(v.total_goals, 0),
+        COALESCE(v.total_assists, 0),
+        COALESCE(v.total_yellow, 0),
+        COALESCE(v.total_red, 0)
+    FROM players p
+    JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
+    JOIN teams t ON t.id = pth.team_id
+    LEFT JOIN v_player_season_stats v 
+           ON v.player_id = p.id
+           AND v.season_id = $2
+           AND v.league_id = $3
+    WHERE p.full_name = $1;
+    `
+	var card PlayerCard
+	var stats Stats
+
+	err := r.db.QueryRow(query, name, seasonID, leagueID).Scan(
+		&card.ID, &card.FullName, &card.Position, &card.Photo_URL, &card.Team,
+		&stats.Goals, &stats.Assists, &stats.YellowCards, &stats.RedCards,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	card.Stats = stats
+	return &card, nil
+}
+
+// ===== Список всех игроков =====
 func (r *repository) GetAllPlayers() ([]PlayerShort, error) {
 	query := `
-        SELECT 
-            p.full_name, 
-            p.position,
-            p.photo_url,
-            t.name AS team_name
-        FROM players p
-        JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
-        JOIN teams t ON t.id = pth.team_id
+    SELECT
+        p.id,
+        p.full_name,
+        p.position,
+        p.photo_url,
+        t.name AS team_name
+    FROM players p
+    JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
+    JOIN teams t ON t.id = pth.team_id;
     `
 	rows, err := r.db.Query(query)
 	if err != nil {
@@ -84,7 +115,7 @@ func (r *repository) GetAllPlayers() ([]PlayerShort, error) {
 	var result []PlayerShort
 	for rows.Next() {
 		var p PlayerShort
-		if err := rows.Scan(&p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
+		if err := rows.Scan(&p.ID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
 			return nil, err
 		}
 		result = append(result, p)
@@ -93,19 +124,20 @@ func (r *repository) GetAllPlayers() ([]PlayerShort, error) {
 	return result, nil
 }
 
+// ===== Поиск игроков =====
 func (r *repository) SearchPlayers(name string) ([]PlayerShort, error) {
 	query := `
-        SELECT
-            p.full_name,
-            p.position,
-            p.photo_url,
-            t.name AS team_name
-        FROM players p
-        JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
-        JOIN teams t ON t.id = pth.team_id
-        WHERE p.full_name ILIKE '%' || $1 || '%'
+    SELECT
+        p.id,
+        p.full_name,
+        p.position,
+        p.photo_url,
+        t.name AS team_name
+    FROM players p
+    JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
+    JOIN teams t ON t.id = pth.team_id
+    WHERE p.full_name ILIKE '%' || $1 || '%';
     `
-
 	rows, err := r.db.Query(query, name)
 	if err != nil {
 		return nil, err
@@ -115,7 +147,7 @@ func (r *repository) SearchPlayers(name string) ([]PlayerShort, error) {
 	var result []PlayerShort
 	for rows.Next() {
 		var p PlayerShort
-		if err := rows.Scan(&p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
+		if err := rows.Scan(&p.ID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
 			return nil, err
 		}
 		result = append(result, p)

--- a/backend/internal/player/usecase.go
+++ b/backend/internal/player/usecase.go
@@ -1,7 +1,8 @@
 package player
 
 type Usecase interface {
-	GetPlayerCardByName(name string) (*PlayerCard, error)
+	GetPlayerCardByID(id, seasonID, leagueID int) (*PlayerCard, error)
+	GetPlayerCardByName(name string, seasonID, leagueID int) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
 	SearchPlayers(name string) ([]PlayerShort, error)
 }
@@ -14,8 +15,12 @@ func NewUsecase(r Repository) Usecase {
 	return &usecase{repo: r}
 }
 
-func (u *usecase) GetPlayerCardByName(name string) (*PlayerCard, error) {
-	return u.repo.GetPlayerCardByName(name)
+func (u *usecase) GetPlayerCardByID(id, seasonID, leagueID int) (*PlayerCard, error) {
+	return u.repo.GetPlayerCardByID(id, seasonID, leagueID)
+}
+
+func (u *usecase) GetPlayerCardByName(name string, seasonID, leagueID int) (*PlayerCard, error) {
+	return u.repo.GetPlayerCardByName(name, seasonID, leagueID)
 }
 
 func (u *usecase) GetAllPlayers() ([]PlayerShort, error) {


### PR DESCRIPTION
## Summary
- compute player season stats from `v_player_season_stats`
- capture season and league in player card requests
- trim player stat model to only exposed fields

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689a6d7c0710832aa3bf6844ededf2ef