### PR TITLE
Use total stats view for player cards

### DIFF
--- a/backend/internal/player/handler.go
+++ b/backend/internal/player/handler.go
@@ -29,10 +29,7 @@ func (h *Handler) getPlayerCard(c *gin.Context) {
 		return
 	}
 
-	seasonID, _ := strconv.Atoi(c.DefaultQuery("season_id", "0"))
-	leagueID, _ := strconv.Atoi(c.DefaultQuery("league_id", "0"))
-
-	playerCard, err := h.uc.GetPlayerCardByID(id, seasonID, leagueID)
+	playerCard, err := h.uc.GetPlayerCardByID(id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "player not found"})
 		return

--- a/backend/internal/player/usecase.go
+++ b/backend/internal/player/usecase.go
@@ -1,8 +1,8 @@
 package player
 
 type Usecase interface {
-	GetPlayerCardByID(id, seasonID, leagueID int) (*PlayerCard, error)
-	GetPlayerCardByName(name string, seasonID, leagueID int) (*PlayerCard, error)
+	GetPlayerCardByID(id int) (*PlayerCard, error)
+	GetPlayerCardByName(name string) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
 	SearchPlayers(name string) ([]PlayerShort, error)
 }
@@ -15,12 +15,12 @@ func NewUsecase(r Repository) Usecase {
 	return &usecase{repo: r}
 }
 
-func (u *usecase) GetPlayerCardByID(id, seasonID, leagueID int) (*PlayerCard, error) {
-	return u.repo.GetPlayerCardByID(id, seasonID, leagueID)
+func (u *usecase) GetPlayerCardByID(id int) (*PlayerCard, error) {
+	return u.repo.GetPlayerCardByID(id)
 }
 
-func (u *usecase) GetPlayerCardByName(name string, seasonID, leagueID int) (*PlayerCard, error) {
-	return u.repo.GetPlayerCardByName(name, seasonID, leagueID)
+func (u *usecase) GetPlayerCardByName(name string) (*PlayerCard, error) {
+	return u.repo.GetPlayerCardByName(name)
 }
 
 func (u *usecase) GetAllPlayers() ([]PlayerShort, error) {


### PR DESCRIPTION
## Summary
- simplify player repository to use `v_player_total_stats` view for player card stats
- drop season and league parameters from repository/usecase and handler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a7f37b448832a96c8fe502bf7c062