### PR TITLE
Implement team endpoints

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"backend/config"
 	"backend/internal/player"
+	"backend/internal/team"
 	"backend/pkg/db"
 	"github.com/gin-contrib/cors"
 	"time"
@@ -15,9 +16,13 @@ func main() {
 	database := db.NewPostgres()
 	defer database.Close()
 
-	repo := player.NewRepository(database)
-	usecase := player.NewUsecase(repo)
-	handler := player.NewHandler(usecase)
+	playerRepo := player.NewRepository(database)
+	playerUsecase := player.NewUsecase(playerRepo)
+	playerHandler := player.NewHandler(playerUsecase)
+
+	teamRepo := team.NewRepository(database)
+	teamUsecase := team.NewUsecase(teamRepo)
+	teamHandler := team.NewHandler(teamUsecase)
 
 	r := gin.Default()
 	r.Static("/static", "./static")
@@ -31,6 +36,7 @@ func main() {
 		MaxAge:           12 * time.Hour,
 	}))
 
-	handler.RegisterRoutes(r)
+	playerHandler.RegisterRoutes(r)
+	teamHandler.RegisterRoutes(r)
 	r.Run(":8080")
 }

--- a/backend/internal/team/handler.go
+++ b/backend/internal/team/handler.go
@@ -1,0 +1,60 @@
+package team
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+	uc Usecase
+}
+
+func NewHandler(u Usecase) *Handler {
+	return &Handler{uc: u}
+}
+
+func (h *Handler) RegisterRoutes(r *gin.Engine) {
+	r.GET("/teams/:id", h.getTeamCard)
+	r.GET("/teams/:id/players", h.getTeamPlayers)
+}
+
+func (h *Handler) getTeamCard(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid team id"})
+		return
+	}
+
+	team, err := h.uc.GetTeamCardByID(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "team not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, team)
+}
+
+func (h *Handler) getTeamPlayers(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid team id"})
+		return
+	}
+
+	if _, err := h.uc.GetTeamCardByID(id); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "team not found"})
+		return
+	}
+
+	players, err := h.uc.GetTeamPlayers(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, players)
+}

--- a/backend/internal/team/model.go
+++ b/backend/internal/team/model.go
@@ -1,0 +1,7 @@
+package team
+
+type TeamCard struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	LogoURL string `json:"logo_url"`
+}

--- a/backend/internal/team/repository.go
+++ b/backend/internal/team/repository.go
@@ -1,0 +1,54 @@
+package team
+
+import (
+	"database/sql"
+
+	"backend/internal/player"
+)
+
+type Repository interface {
+	GetTeamByID(id int) (*TeamCard, error)
+	GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error)
+}
+
+type repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) Repository {
+	return &repository{db: db}
+}
+
+func (r *repository) GetTeamByID(id int) (*TeamCard, error) {
+	query := `SELECT id, name, logo_url FROM teams WHERE id = $1;`
+	var t TeamCard
+	if err := r.db.QueryRow(query, id).Scan(&t.ID, &t.Name, &t.LogoURL); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *repository) GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error) {
+	query := `
+        SELECT p.id, p.full_name, p.position, p.photo_url, t.name
+        FROM players p
+        JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
+        JOIN teams t ON t.id = pth.team_id
+        WHERE t.id = $1;
+        `
+	rows, err := r.db.Query(query, teamID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []player.PlayerShort
+	for rows.Next() {
+		var p player.PlayerShort
+		if err := rows.Scan(&p.ID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+	}
+	return result, nil
+}

--- a/backend/internal/team/usecase.go
+++ b/backend/internal/team/usecase.go
@@ -1,0 +1,24 @@
+package team
+
+import "backend/internal/player"
+
+type Usecase interface {
+	GetTeamCardByID(id int) (*TeamCard, error)
+	GetTeamPlayers(id int) ([]player.PlayerShort, error)
+}
+
+type usecase struct {
+	repo Repository
+}
+
+func NewUsecase(r Repository) Usecase {
+	return &usecase{repo: r}
+}
+
+func (u *usecase) GetTeamCardByID(id int) (*TeamCard, error) {
+	return u.repo.GetTeamByID(id)
+}
+
+func (u *usecase) GetTeamPlayers(id int) ([]player.PlayerShort, error) {
+	return u.repo.GetPlayersByTeamID(id)
+}


### PR DESCRIPTION
## Summary
- add team module with handler, usecase, repository and model
- expose GET /teams/{id} and /teams/{id}/players endpoints
- wire team routes in main

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a9cc1aa34832a947b661d0494971c