### PR TITLE
Unify player listing and search

### DIFF
--- a/backend/internal/player/usecase.go
+++ b/backend/internal/player/usecase.go
@@ -4,7 +4,7 @@ type Usecase interface {
 	GetPlayerCardByID(id int) (*PlayerCard, error)
 	GetPlayerCardByName(name string) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
-	SearchPlayers(name string) ([]PlayerShort, error)
+	SearchPlayers(name string, leagueID, teamID int) ([]PlayerShort, error)
 }
 
 type usecase struct {
@@ -27,6 +27,6 @@ func (u *usecase) GetAllPlayers() ([]PlayerShort, error) {
 	return u.repo.GetAllPlayers()
 }
 
-func (u *usecase) SearchPlayers(name string) ([]PlayerShort, error) {
-	return u.repo.SearchPlayers(name)
+func (u *usecase) SearchPlayers(name string, leagueID, teamID int) ([]PlayerShort, error) {
+	return u.repo.SearchPlayers(name, leagueID, teamID)
 }


### PR DESCRIPTION
## Summary
- merge player list and search handlers into a single `/players` endpoint
- add optional query parameters to filter by name, league, or team
- support combined filtering logic in usecase and repository

## Testing
- `go test ./...` *(fails: command hangs, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_689aa74609e4832abb80ba4cbc34635a