### PR TITLE
Add team roster to team card and list teams endpoint

### DIFF
--- a/backend/internal/team/handler.go
+++ b/backend/internal/team/handler.go
@@ -16,8 +16,8 @@ func NewHandler(u Usecase) *Handler {
 }
 
 func (h *Handler) RegisterRoutes(r *gin.Engine) {
+	r.GET("/teams", h.getTeams)
 	r.GET("/teams/:id", h.getTeamCard)
-	r.GET("/teams/:id/players", h.getTeamPlayers)
 }
 
 func (h *Handler) getTeamCard(c *gin.Context) {
@@ -37,24 +37,12 @@ func (h *Handler) getTeamCard(c *gin.Context) {
 	c.JSON(http.StatusOK, team)
 }
 
-func (h *Handler) getTeamPlayers(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid team id"})
-		return
-	}
-
-	if _, err := h.uc.GetTeamCardByID(id); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "team not found"})
-		return
-	}
-
-	players, err := h.uc.GetTeamPlayers(id)
+func (h *Handler) getTeams(c *gin.Context) {
+	teams, err := h.uc.GetTeams()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, players)
+	c.JSON(http.StatusOK, teams)
 }

--- a/backend/internal/team/model.go
+++ b/backend/internal/team/model.go
@@ -1,7 +1,10 @@
 package team
 
+import "backend/internal/player"
+
 type TeamCard struct {
-	ID      int    `json:"id"`
-	Name    string `json:"name"`
-	LogoURL string `json:"logo_url"`
+	ID      int                  `json:"id"`
+	Name    string               `json:"name"`
+	LogoURL string               `json:"logo_url"`
+	Players []player.PlayerShort `json:"players"`
 }

--- a/backend/internal/team/repository.go
+++ b/backend/internal/team/repository.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Repository interface {
+	GetTeams() ([]TeamCard, error)
 	GetTeamByID(id int) (*TeamCard, error)
 	GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error)
 }
@@ -17,6 +18,25 @@ type repository struct {
 
 func NewRepository(db *sql.DB) Repository {
 	return &repository{db: db}
+}
+
+func (r *repository) GetTeams() ([]TeamCard, error) {
+	query := `SELECT id, name, logo_url FROM teams;`
+	rows, err := r.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var teams []TeamCard
+	for rows.Next() {
+		var t TeamCard
+		if err := rows.Scan(&t.ID, &t.Name, &t.LogoURL); err != nil {
+			return nil, err
+		}
+		teams = append(teams, t)
+	}
+	return teams, nil
 }
 
 func (r *repository) GetTeamByID(id int) (*TeamCard, error) {

--- a/backend/internal/team/usecase.go
+++ b/backend/internal/team/usecase.go
@@ -1,10 +1,8 @@
 package team
 
-import "backend/internal/player"
-
 type Usecase interface {
 	GetTeamCardByID(id int) (*TeamCard, error)
-	GetTeamPlayers(id int) ([]player.PlayerShort, error)
+	GetTeams() ([]TeamCard, error)
 }
 
 type usecase struct {
@@ -16,9 +14,18 @@ func NewUsecase(r Repository) Usecase {
 }
 
 func (u *usecase) GetTeamCardByID(id int) (*TeamCard, error) {
-	return u.repo.GetTeamByID(id)
+	team, err := u.repo.GetTeamByID(id)
+	if err != nil {
+		return nil, err
+	}
+	players, err := u.repo.GetPlayersByTeamID(id)
+	if err != nil {
+		return nil, err
+	}
+	team.Players = players
+	return team, nil
 }
 
-func (u *usecase) GetTeamPlayers(id int) ([]player.PlayerShort, error) {
-	return u.repo.GetPlayersByTeamID(id)
+func (u *usecase) GetTeams() ([]TeamCard, error) {
+	return u.repo.GetTeams()
 }


### PR DESCRIPTION
## Summary
- Include players in team card and remove dedicated players endpoint
- Add repository and usecase methods to fetch all teams
- Add /teams route and return team roster in single team view

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aabc1107c832a81a2466397dbc71e