### PR TITLE
Add endpoints to link teams with leagues and players with teams

### DIFF
--- a/backend/internal/player/handler.go
+++ b/backend/internal/player/handler.go
@@ -19,6 +19,7 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	r.GET("/players", h.getPlayers)
 	r.GET("/players/:id", h.getPlayerCard)
 	r.POST("/players", h.createPlayer)
+	r.POST("/player-team", h.addPlayerToTeam)
 }
 
 func (h *Handler) getPlayerCard(c *gin.Context) {
@@ -45,6 +46,21 @@ func (h *Handler) createPlayer(c *gin.Context) {
 	}
 
 	id, err := h.uc.CreatePlayer(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"id": id})
+}
+
+func (h *Handler) addPlayerToTeam(c *gin.Context) {
+	var req PlayerTeam
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := h.uc.AddPlayerToTeam(req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/player/model.go
+++ b/backend/internal/player/model.go
@@ -30,3 +30,8 @@ type NewPlayer struct {
 	PhotoURL string `json:"photo_url"`
 	TeamID   int    `json:"team_id"`
 }
+
+type PlayerTeam struct {
+	PlayerID int `json:"player_id"`
+	TeamID   int `json:"team_id"`
+}

--- a/backend/internal/player/usecase.go
+++ b/backend/internal/player/usecase.go
@@ -6,6 +6,7 @@ type Usecase interface {
 	GetAllPlayers() ([]PlayerShort, error)
 	SearchPlayers(name string, leagueID, teamID int) ([]PlayerShort, error)
 	CreatePlayer(p NewPlayer) (int, error)
+	AddPlayerToTeam(pt PlayerTeam) (int, error)
 }
 
 type usecase struct {
@@ -34,4 +35,8 @@ func (u *usecase) SearchPlayers(name string, leagueID, teamID int) ([]PlayerShor
 
 func (u *usecase) CreatePlayer(p NewPlayer) (int, error) {
 	return u.repo.CreatePlayer(p)
+}
+
+func (u *usecase) AddPlayerToTeam(pt PlayerTeam) (int, error) {
+	return u.repo.AddPlayerToTeam(pt)
 }

--- a/backend/internal/team/handler.go
+++ b/backend/internal/team/handler.go
@@ -19,6 +19,7 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	r.GET("/teams", h.getTeams)
 	r.GET("/teams/:id", h.getTeamCard)
 	r.POST("/teams", h.createTeam)
+	r.POST("/team-league", h.assignTeamToLeagueSeason)
 }
 
 func (h *Handler) getTeamCard(c *gin.Context) {
@@ -56,6 +57,21 @@ func (h *Handler) createTeam(c *gin.Context) {
 	}
 
 	id, err := h.uc.CreateTeam(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"id": id})
+}
+
+func (h *Handler) assignTeamToLeagueSeason(c *gin.Context) {
+	var req TeamLeagueSeason
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := h.uc.AssignTeamToLeagueSeason(req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/team/model.go
+++ b/backend/internal/team/model.go
@@ -13,3 +13,9 @@ type NewTeam struct {
 	Name    string `json:"name"`
 	LogoURL string `json:"logo_url"`
 }
+
+type TeamLeagueSeason struct {
+	TeamID   int `json:"team_id"`
+	LeagueID int `json:"league_id"`
+	SeasonID int `json:"season_id"`
+}

--- a/backend/internal/team/repository.go
+++ b/backend/internal/team/repository.go
@@ -11,6 +11,7 @@ type Repository interface {
 	GetTeamByID(id int) (*TeamCard, error)
 	GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error)
 	CreateTeam(t NewTeam) (int, error)
+	AssignTeamToLeagueSeason(tls TeamLeagueSeason) (int, error)
 }
 
 type repository struct {
@@ -84,4 +85,16 @@ func (r *repository) GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error
 		result = append(result, p)
 	}
 	return result, nil
+}
+
+func (r *repository) AssignTeamToLeagueSeason(tls TeamLeagueSeason) (int, error) {
+	var id int
+	err := r.db.QueryRow(
+		"INSERT INTO team_league_season (team_id, league_id, season_id) VALUES ($1, $2, $3) RETURNING id",
+		tls.TeamID, tls.LeagueID, tls.SeasonID,
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
 }

--- a/backend/internal/team/usecase.go
+++ b/backend/internal/team/usecase.go
@@ -4,6 +4,7 @@ type Usecase interface {
 	GetTeamCardByID(id int) (*TeamCard, error)
 	GetTeams() ([]TeamCard, error)
 	CreateTeam(t NewTeam) (int, error)
+	AssignTeamToLeagueSeason(tls TeamLeagueSeason) (int, error)
 }
 
 type usecase struct {
@@ -33,4 +34,8 @@ func (u *usecase) GetTeams() ([]TeamCard, error) {
 
 func (u *usecase) CreateTeam(t NewTeam) (int, error) {
 	return u.repo.CreateTeam(t)
+}
+
+func (u *usecase) AssignTeamToLeagueSeason(tls TeamLeagueSeason) (int, error) {
+	return u.repo.AssignTeamToLeagueSeason(tls)
 }


### PR DESCRIPTION
## Summary
- add POST /team-league to bind a team with a league and season
- add POST /player-team to move a player to a team with history tracking

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ac09356f0832ab1c7daa525710247