### PR TITLE
Add endpoints for rounds, matches, and player stats

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"backend/config"
 	"backend/internal/league"
+	"backend/internal/match"
 	"backend/internal/player"
 	"backend/internal/team"
 	"backend/pkg/db"
@@ -29,12 +30,16 @@ func main() {
 	leagueUsecase := league.NewUsecase(leagueRepo)
 	leagueHandler := league.NewHandler(leagueUsecase)
 
+	matchRepo := match.NewRepository(database)
+	matchUsecase := match.NewUsecase(matchRepo)
+	matchHandler := match.NewHandler(matchUsecase)
+
 	r := gin.Default()
 	r.Static("/static", "./static")
 
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:5173"},
-		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
+		AllowMethods:     []string{"GET", "POST", "OPTIONS", "PATCH"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept"},
 		ExposeHeaders:    []string{"Content-Length"},
 		AllowCredentials: true,
@@ -44,5 +49,6 @@ func main() {
 	playerHandler.RegisterRoutes(r)
 	teamHandler.RegisterRoutes(r)
 	leagueHandler.RegisterRoutes(r)
+	matchHandler.RegisterRoutes(r)
 	r.Run(":8080")
 }

--- a/backend/internal/match/handler.go
+++ b/backend/internal/match/handler.go
@@ -1,0 +1,127 @@
+package match
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler handles HTTP routes for match related operations
+type Handler struct {
+	uc Usecase
+}
+
+func NewHandler(u Usecase) *Handler {
+	return &Handler{uc: u}
+}
+
+// RegisterRoutes registers match related endpoints
+func (h *Handler) RegisterRoutes(r *gin.Engine) {
+	r.POST("/api/rounds", h.createRound)
+	r.POST("/api/matches", h.createMatch)
+	r.POST("/api/match-participation", h.addMatchParticipation)
+	r.POST("/api/player-stats", h.addPlayerStats)
+	r.PATCH("/api/matches/:id", h.updateMatchScore)
+	r.GET("/api/matches", h.listMatches)
+	r.GET("/api/matches/:id", h.getMatch)
+}
+
+func (h *Handler) createRound(c *gin.Context) {
+	var req NewRound
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.uc.CreateRound(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"round_id": id})
+}
+
+func (h *Handler) createMatch(c *gin.Context) {
+	var req NewMatch
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.uc.CreateMatch(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"match_id": id})
+}
+
+func (h *Handler) addMatchParticipation(c *gin.Context) {
+	var req MatchParticipation
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.uc.AddMatchParticipation(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"match_participation_id": id})
+}
+
+func (h *Handler) addPlayerStats(c *gin.Context) {
+	var req PlayerStats
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.uc.AddPlayerStats(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"id": id})
+}
+
+func (h *Handler) updateMatchScore(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid match id"})
+		return
+	}
+	var req MatchScore
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.uc.UpdateMatchScore(id, req); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "updated"})
+}
+
+func (h *Handler) listMatches(c *gin.Context) {
+	matches, err := h.uc.ListMatches()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, matches)
+}
+
+func (h *Handler) getMatch(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid match id"})
+		return
+	}
+	match, err := h.uc.GetMatchDetails(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "match not found"})
+		return
+	}
+	c.JSON(http.StatusOK, match)
+}

--- a/backend/internal/match/model.go
+++ b/backend/internal/match/model.go
@@ -1,0 +1,71 @@
+package match
+
+// NewRound represents the payload to create a round
+type NewRound struct {
+	SeasonID    int `json:"season_id"`
+	LeagueID    int `json:"league_id"`
+	RoundNumber int `json:"round_number"`
+}
+
+// NewMatch represents the payload to create a match
+type NewMatch struct {
+	Date       string `json:"date"`
+	HomeTeamID int    `json:"home_team_id"`
+	AwayTeamID int    `json:"away_team_id"`
+	SeasonID   int    `json:"season_id"`
+	RoundID    int    `json:"round_id"`
+	HomeScore  int    `json:"home_score"`
+	AwayScore  int    `json:"away_score"`
+}
+
+// MatchParticipation represents player participation in a match
+type MatchParticipation struct {
+	MatchID    int  `json:"match_id"`
+	PlayerID   int  `json:"player_id"`
+	TeamID     int  `json:"team_id"`
+	IsStarting bool `json:"is_starting"`
+}
+
+// PlayerStats represents statistics for a player in a match
+type PlayerStats struct {
+	MatchParticipationID int `json:"match_participation_id"`
+	Goals                int `json:"goals"`
+	Assists              int `json:"assists"`
+	YellowCards          int `json:"yellow_cards"`
+	RedCards             int `json:"red_cards"`
+}
+
+// MatchScore is used to update the final score of a match
+type MatchScore struct {
+	HomeScore int `json:"home_score"`
+	AwayScore int `json:"away_score"`
+}
+
+// Match represents a stored match with scores
+type Match struct {
+	ID         int    `json:"id"`
+	Date       string `json:"date"`
+	HomeTeamID int    `json:"home_team_id"`
+	AwayTeamID int    `json:"away_team_id"`
+	SeasonID   int    `json:"season_id"`
+	RoundID    int    `json:"round_id"`
+	HomeScore  int    `json:"home_score"`
+	AwayScore  int    `json:"away_score"`
+}
+
+// ParticipantStats combines participation and player stats
+type ParticipantStats struct {
+	PlayerID    int  `json:"player_id"`
+	TeamID      int  `json:"team_id"`
+	IsStarting  bool `json:"is_starting"`
+	Goals       int  `json:"goals"`
+	Assists     int  `json:"assists"`
+	YellowCards int  `json:"yellow_cards"`
+	RedCards    int  `json:"red_cards"`
+}
+
+// MatchDetails contains match info and participant statistics
+type MatchDetails struct {
+	Match
+	Participants []ParticipantStats `json:"participants"`
+}

--- a/backend/internal/match/repository.go
+++ b/backend/internal/match/repository.go
@@ -1,0 +1,130 @@
+package match
+
+import "database/sql"
+
+// Repository defines methods to interact with matches related tables
+type Repository interface {
+	CreateRound(nr NewRound) (int, error)
+	CreateMatch(nm NewMatch) (int, error)
+	CreateMatchParticipation(mp MatchParticipation) (int, error)
+	CreatePlayerStats(ps PlayerStats) (int, error)
+	UpdateMatchScore(id int, ms MatchScore) error
+	ListMatches() ([]Match, error)
+	GetMatchDetails(id int) (*MatchDetails, error)
+}
+
+type repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) Repository {
+	return &repository{db: db}
+}
+
+func (r *repository) CreateRound(nr NewRound) (int, error) {
+	var id int
+	err := r.db.QueryRow(
+		"INSERT INTO rounds (season_id, league_id, round_number) VALUES ($1, $2, $3) RETURNING id",
+		nr.SeasonID, nr.LeagueID, nr.RoundNumber,
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (r *repository) CreateMatch(nm NewMatch) (int, error) {
+	var id int
+	err := r.db.QueryRow(
+		"INSERT INTO matches (date, home_team_id, away_team_id, season_id, round_id, home_score, away_score) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
+		nm.Date, nm.HomeTeamID, nm.AwayTeamID, nm.SeasonID, nm.RoundID, nm.HomeScore, nm.AwayScore,
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (r *repository) CreateMatchParticipation(mp MatchParticipation) (int, error) {
+	var id int
+	err := r.db.QueryRow(
+		"INSERT INTO match_participation (match_id, player_id, team_id, is_starting) VALUES ($1, $2, $3, $4) RETURNING id",
+		mp.MatchID, mp.PlayerID, mp.TeamID, mp.IsStarting,
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (r *repository) CreatePlayerStats(ps PlayerStats) (int, error) {
+	var id int
+	err := r.db.QueryRow(
+		"INSERT INTO player_stats (match_participation_id, goals, assists, yellow_cards, red_cards) VALUES ($1, $2, $3, $4, $5) RETURNING id",
+		ps.MatchParticipationID, ps.Goals, ps.Assists, ps.YellowCards, ps.RedCards,
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (r *repository) UpdateMatchScore(id int, ms MatchScore) error {
+	_, err := r.db.Exec(
+		"UPDATE matches SET home_score = $1, away_score = $2 WHERE id = $3",
+		ms.HomeScore, ms.AwayScore, id,
+	)
+	return err
+}
+
+func (r *repository) ListMatches() ([]Match, error) {
+	rows, err := r.db.Query(
+		"SELECT id, date, home_team_id, away_team_id, season_id, round_id, home_score, away_score FROM matches",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var matches []Match
+	for rows.Next() {
+		var m Match
+		if err := rows.Scan(&m.ID, &m.Date, &m.HomeTeamID, &m.AwayTeamID, &m.SeasonID, &m.RoundID, &m.HomeScore, &m.AwayScore); err != nil {
+			return nil, err
+		}
+		matches = append(matches, m)
+	}
+
+	return matches, rows.Err()
+}
+
+func (r *repository) GetMatchDetails(id int) (*MatchDetails, error) {
+	var m Match
+	err := r.db.QueryRow(
+		"SELECT id, date, home_team_id, away_team_id, season_id, round_id, home_score, away_score FROM matches WHERE id = $1",
+		id,
+	).Scan(&m.ID, &m.Date, &m.HomeTeamID, &m.AwayTeamID, &m.SeasonID, &m.RoundID, &m.HomeScore, &m.AwayScore)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := r.db.Query(
+		"SELECT mp.player_id, mp.team_id, mp.is_starting, COALESCE(ps.goals, 0), COALESCE(ps.assists, 0), COALESCE(ps.yellow_cards, 0), COALESCE(ps.red_cards, 0) FROM match_participation mp LEFT JOIN player_stats ps ON ps.match_participation_id = mp.id WHERE mp.match_id = $1",
+		id,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var participants []ParticipantStats
+	for rows.Next() {
+		var p ParticipantStats
+		if err := rows.Scan(&p.PlayerID, &p.TeamID, &p.IsStarting, &p.Goals, &p.Assists, &p.YellowCards, &p.RedCards); err != nil {
+			return nil, err
+		}
+		participants = append(participants, p)
+	}
+
+	return &MatchDetails{Match: m, Participants: participants}, rows.Err()
+}

--- a/backend/internal/match/usecase.go
+++ b/backend/internal/match/usecase.go
@@ -1,0 +1,48 @@
+package match
+
+// Usecase provides business logic for matches and related entities
+type Usecase interface {
+	CreateRound(nr NewRound) (int, error)
+	CreateMatch(nm NewMatch) (int, error)
+	AddMatchParticipation(mp MatchParticipation) (int, error)
+	AddPlayerStats(ps PlayerStats) (int, error)
+	UpdateMatchScore(id int, ms MatchScore) error
+	ListMatches() ([]Match, error)
+	GetMatchDetails(id int) (*MatchDetails, error)
+}
+
+type usecase struct {
+	repo Repository
+}
+
+func NewUsecase(r Repository) Usecase {
+	return &usecase{repo: r}
+}
+
+func (u *usecase) CreateRound(nr NewRound) (int, error) {
+	return u.repo.CreateRound(nr)
+}
+
+func (u *usecase) CreateMatch(nm NewMatch) (int, error) {
+	return u.repo.CreateMatch(nm)
+}
+
+func (u *usecase) AddMatchParticipation(mp MatchParticipation) (int, error) {
+	return u.repo.CreateMatchParticipation(mp)
+}
+
+func (u *usecase) AddPlayerStats(ps PlayerStats) (int, error) {
+	return u.repo.CreatePlayerStats(ps)
+}
+
+func (u *usecase) UpdateMatchScore(id int, ms MatchScore) error {
+	return u.repo.UpdateMatchScore(id, ms)
+}
+
+func (u *usecase) ListMatches() ([]Match, error) {
+	return u.repo.ListMatches()
+}
+
+func (u *usecase) GetMatchDetails(id int) (*MatchDetails, error) {
+	return u.repo.GetMatchDetails(id)
+}


### PR DESCRIPTION
## Summary
- add repository, usecase, and handlers for rounds, matches, match participation, and player stats
- expose POST /api/rounds, /api/matches, /api/match-participation, /api/player-stats, PATCH /api/matches/:id, and GET /api/matches and /api/matches/:id
- register new routes and enable PATCH in CORS configuration

## Testing
- `timeout 30 go vet ./...`
- `timeout 30 go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689acb827968832a8e9b7a9730eeddd0