### PR TITLE
Refactor schema and compute player stats from match data

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.23.2
 require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.10.1
+	github.com/google/uuid v1.5.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -31,6 +31,8 @@ github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/backend/internal/match/model.go
+++ b/backend/internal/match/model.go
@@ -30,7 +30,7 @@ type MatchParticipation struct {
 type PlayerStats struct {
 	MatchParticipationID int `json:"match_participation_id"`
 	Goals                int `json:"goals"`
-	Assists              int `json:"assists"`
+	Passes               int `json:"passes"`
 	YellowCards          int `json:"yellow_cards"`
 	RedCards             int `json:"red_cards"`
 }
@@ -59,7 +59,7 @@ type ParticipantStats struct {
 	TeamID      int  `json:"team_id"`
 	IsStarting  bool `json:"is_starting"`
 	Goals       int  `json:"goals"`
-	Assists     int  `json:"assists"`
+	Passes      int  `json:"passes"`
 	YellowCards int  `json:"yellow_cards"`
 	RedCards    int  `json:"red_cards"`
 }

--- a/backend/internal/match/repository.go
+++ b/backend/internal/match/repository.go
@@ -60,8 +60,8 @@ func (r *repository) CreateMatchParticipation(mp MatchParticipation) (int, error
 func (r *repository) CreatePlayerStats(ps PlayerStats) (int, error) {
 	var id int
 	err := r.db.QueryRow(
-		"INSERT INTO player_stats (match_participation_id, goals, assists, yellow_cards, red_cards) VALUES ($1, $2, $3, $4, $5) RETURNING id",
-		ps.MatchParticipationID, ps.Goals, ps.Assists, ps.YellowCards, ps.RedCards,
+		"INSERT INTO player_stats (match_participation_id, goals, passes, yellow_cards, red_cards) VALUES ($1, $2, $3, $4, $5) RETURNING id",
+		ps.MatchParticipationID, ps.Goals, ps.Passes, ps.YellowCards, ps.RedCards,
 	).Scan(&id)
 	if err != nil {
 		return 0, err
@@ -109,7 +109,7 @@ func (r *repository) GetMatchDetails(id int) (*MatchDetails, error) {
 	}
 
 	rows, err := r.db.Query(
-		"SELECT mp.player_id, mp.team_id, mp.is_starting, COALESCE(ps.goals, 0), COALESCE(ps.assists, 0), COALESCE(ps.yellow_cards, 0), COALESCE(ps.red_cards, 0) FROM match_participation mp LEFT JOIN player_stats ps ON ps.match_participation_id = mp.id WHERE mp.match_id = $1",
+		"SELECT mp.player_id, mp.team_id, mp.is_starting, COALESCE(ps.goals, 0), COALESCE(ps.passes, 0), COALESCE(ps.yellow_cards, 0), COALESCE(ps.red_cards, 0) FROM match_participation mp LEFT JOIN player_stats ps ON ps.match_participation_id = mp.id WHERE mp.match_id = $1",
 		id,
 	)
 	if err != nil {
@@ -120,7 +120,7 @@ func (r *repository) GetMatchDetails(id int) (*MatchDetails, error) {
 	var participants []ParticipantStats
 	for rows.Next() {
 		var p ParticipantStats
-		if err := rows.Scan(&p.PlayerID, &p.TeamID, &p.IsStarting, &p.Goals, &p.Assists, &p.YellowCards, &p.RedCards); err != nil {
+		if err := rows.Scan(&p.PlayerID, &p.TeamID, &p.IsStarting, &p.Goals, &p.Passes, &p.YellowCards, &p.RedCards); err != nil {
 			return nil, err
 		}
 		participants = append(participants, p)

--- a/backend/internal/player/handler.go
+++ b/backend/internal/player/handler.go
@@ -17,20 +17,15 @@ func NewHandler(u Usecase) *Handler {
 
 func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	r.GET("/players", h.getPlayers)
-	r.GET("/players/:id", h.getPlayerCard)
+	r.GET("/players/:uid", h.getPlayerCard)
 	r.POST("/players", h.createPlayer)
 	r.POST("/player-team", h.addPlayerToTeam)
 }
 
 func (h *Handler) getPlayerCard(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid player id"})
-		return
-	}
+	uid := c.Param("uid")
 
-	playerCard, err := h.uc.GetPlayerCardByID(id)
+	playerCard, err := h.uc.GetPlayerCardByUID(uid)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "player not found"})
 		return
@@ -45,12 +40,12 @@ func (h *Handler) createPlayer(c *gin.Context) {
 		return
 	}
 
-	id, err := h.uc.CreatePlayer(req)
+	uid, err := h.uc.CreatePlayer(req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"id": id})
+	c.JSON(http.StatusCreated, gin.H{"uid": uid})
 }
 
 func (h *Handler) addPlayerToTeam(c *gin.Context) {

--- a/backend/internal/player/model.go
+++ b/backend/internal/player/model.go
@@ -2,13 +2,16 @@ package player
 
 type Stats struct {
 	Goals       int `json:"goals"`
-	Assists     int `json:"assists"`
+	Passes      int `json:"passes"`
 	YellowCards int `json:"yellow_cards"`
 	RedCards    int `json:"red_cards"`
+	Wins        int `json:"wins"`
+	Losses      int `json:"losses"`
 }
 
 type PlayerCard struct {
 	ID        int    `json:"id"`
+	UID       string `json:"uid"`
 	FullName  string `json:"full_name"`
 	Position  string `json:"position"`
 	Photo_URL string `json:"photo_url"`
@@ -18,6 +21,7 @@ type PlayerCard struct {
 
 type PlayerShort struct {
 	ID        int    `json:"id"`
+	UID       string `json:"uid"`
 	FullName  string `json:"full_name"`
 	Position  string `json:"position"`
 	Photo_URL string `json:"photo_url"`

--- a/backend/internal/player/repository.go
+++ b/backend/internal/player/repository.go
@@ -4,14 +4,16 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Repository interface {
-	GetPlayerCardByID(id int) (*PlayerCard, error)
+	GetPlayerCardByUID(uid string) (*PlayerCard, error)
 	GetPlayerCardByName(name string) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
 	SearchPlayers(name string, leagueID, teamID int) ([]PlayerShort, error)
-	CreatePlayer(p NewPlayer) (int, error)
+	CreatePlayer(p NewPlayer) (string, error)
 	AddPlayerToTeam(pt PlayerTeam) (int, error)
 }
 
@@ -23,31 +25,34 @@ func NewRepository(db *sql.DB) Repository {
 	return &repository{db: db}
 }
 
-// ===== Карточка игрока по ID =====
-func (r *repository) GetPlayerCardByID(id int) (*PlayerCard, error) {
+// ===== Карточка игрока по UID =====
+func (r *repository) GetPlayerCardByUID(uid string) (*PlayerCard, error) {
 	query := `
     SELECT
         p.id,
+        p.uid,
         p.full_name,
         p.position,
         p.photo_url,
         t.name AS team_name,
         COALESCE(v.total_goals, 0),
-        COALESCE(v.total_assists, 0),
+        COALESCE(v.total_passes, 0),
         COALESCE(v.total_yellow, 0),
-        COALESCE(v.total_red, 0)
+        COALESCE(v.total_red, 0),
+        COALESCE(v.total_wins, 0),
+        COALESCE(v.total_losses, 0)
     FROM players p
     JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
     JOIN teams t ON t.id = pth.team_id
     LEFT JOIN v_player_total_stats v ON v.player_id = p.id
-    WHERE p.id = $1;
+    WHERE p.uid = $1;
     `
 	var card PlayerCard
 	var stats Stats
 
-	err := r.db.QueryRow(query, id).Scan(
-		&card.ID, &card.FullName, &card.Position, &card.Photo_URL, &card.Team,
-		&stats.Goals, &stats.Assists, &stats.YellowCards, &stats.RedCards,
+	err := r.db.QueryRow(query, uid).Scan(
+		&card.ID, &card.UID, &card.FullName, &card.Position, &card.Photo_URL, &card.Team,
+		&stats.Goals, &stats.Passes, &stats.YellowCards, &stats.RedCards, &stats.Wins, &stats.Losses,
 	)
 	if err != nil {
 		return nil, err
@@ -62,14 +67,17 @@ func (r *repository) GetPlayerCardByName(name string) (*PlayerCard, error) {
 	query := `
     SELECT
         p.id,
+        p.uid,
         p.full_name,
         p.position,
         p.photo_url,
         t.name AS team_name,
         COALESCE(v.total_goals, 0),
-        COALESCE(v.total_assists, 0),
+        COALESCE(v.total_passes, 0),
         COALESCE(v.total_yellow, 0),
-        COALESCE(v.total_red, 0)
+        COALESCE(v.total_red, 0),
+        COALESCE(v.total_wins, 0),
+        COALESCE(v.total_losses, 0)
     FROM players p
     JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
     JOIN teams t ON t.id = pth.team_id
@@ -80,8 +88,8 @@ func (r *repository) GetPlayerCardByName(name string) (*PlayerCard, error) {
 	var stats Stats
 
 	err := r.db.QueryRow(query, name).Scan(
-		&card.ID, &card.FullName, &card.Position, &card.Photo_URL, &card.Team,
-		&stats.Goals, &stats.Assists, &stats.YellowCards, &stats.RedCards,
+		&card.ID, &card.UID, &card.FullName, &card.Position, &card.Photo_URL, &card.Team,
+		&stats.Goals, &stats.Passes, &stats.YellowCards, &stats.RedCards, &stats.Wins, &stats.Losses,
 	)
 	if err != nil {
 		return nil, err
@@ -96,6 +104,7 @@ func (r *repository) GetAllPlayers() ([]PlayerShort, error) {
 	query := `
     SELECT
         p.id,
+        p.uid,
         p.full_name,
         p.position,
         p.photo_url,
@@ -113,7 +122,7 @@ func (r *repository) GetAllPlayers() ([]PlayerShort, error) {
 	var result []PlayerShort
 	for rows.Next() {
 		var p PlayerShort
-		if err := rows.Scan(&p.ID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
+		if err := rows.Scan(&p.ID, &p.UID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
 			return nil, err
 		}
 		result = append(result, p)
@@ -127,6 +136,7 @@ func (r *repository) SearchPlayers(name string, leagueID, teamID int) ([]PlayerS
 	query := `
     SELECT
         p.id,
+        p.uid,
         p.full_name,
         p.position,
         p.photo_url,
@@ -164,7 +174,7 @@ func (r *repository) SearchPlayers(name string, leagueID, teamID int) ([]PlayerS
 	var result []PlayerShort
 	for rows.Next() {
 		var p PlayerShort
-		if err := rows.Scan(&p.ID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
+		if err := rows.Scan(&p.ID, &p.UID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
 			return nil, err
 		}
 		result = append(result, p)
@@ -173,35 +183,36 @@ func (r *repository) SearchPlayers(name string, leagueID, teamID int) ([]PlayerS
 	return result, nil
 }
 
-func (r *repository) CreatePlayer(p NewPlayer) (int, error) {
+func (r *repository) CreatePlayer(p NewPlayer) (string, error) {
+	uid := uuid.NewString()
 	tx, err := r.db.Begin()
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
-	var id int
+	var playerID int
 	err = tx.QueryRow(
-		"INSERT INTO players (full_name, position, photo_url) VALUES ($1, $2, $3) RETURNING id",
-		p.FullName, p.Position, p.PhotoURL,
-	).Scan(&id)
+		"INSERT INTO players (uid, full_name, position, photo_url) VALUES ($1, $2, $3, $4) RETURNING id",
+		uid, p.FullName, p.Position, p.PhotoURL,
+	).Scan(&playerID)
 	if err != nil {
 		tx.Rollback()
-		return 0, err
+		return "", err
 	}
 
 	_, err = tx.Exec(
 		"INSERT INTO player_team_history (player_id, team_id, start_date) VALUES ($1, $2, $3)",
-		id, p.TeamID, time.Now(),
+		playerID, p.TeamID, time.Now(),
 	)
 	if err != nil {
 		tx.Rollback()
-		return 0, err
+		return "", err
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, err
+		return "", err
 	}
-	return id, nil
+	return uid, nil
 }
 
 func (r *repository) AddPlayerToTeam(pt PlayerTeam) (int, error) {

--- a/backend/internal/player/usecase.go
+++ b/backend/internal/player/usecase.go
@@ -1,11 +1,11 @@
 package player
 
 type Usecase interface {
-	GetPlayerCardByID(id int) (*PlayerCard, error)
+	GetPlayerCardByUID(uid string) (*PlayerCard, error)
 	GetPlayerCardByName(name string) (*PlayerCard, error)
 	GetAllPlayers() ([]PlayerShort, error)
 	SearchPlayers(name string, leagueID, teamID int) ([]PlayerShort, error)
-	CreatePlayer(p NewPlayer) (int, error)
+	CreatePlayer(p NewPlayer) (string, error)
 	AddPlayerToTeam(pt PlayerTeam) (int, error)
 }
 
@@ -17,8 +17,8 @@ func NewUsecase(r Repository) Usecase {
 	return &usecase{repo: r}
 }
 
-func (u *usecase) GetPlayerCardByID(id int) (*PlayerCard, error) {
-	return u.repo.GetPlayerCardByID(id)
+func (u *usecase) GetPlayerCardByUID(uid string) (*PlayerCard, error) {
+	return u.repo.GetPlayerCardByUID(uid)
 }
 
 func (u *usecase) GetPlayerCardByName(name string) (*PlayerCard, error) {
@@ -33,7 +33,7 @@ func (u *usecase) SearchPlayers(name string, leagueID, teamID int) ([]PlayerShor
 	return u.repo.SearchPlayers(name, leagueID, teamID)
 }
 
-func (u *usecase) CreatePlayer(p NewPlayer) (int, error) {
+func (u *usecase) CreatePlayer(p NewPlayer) (string, error) {
 	return u.repo.CreatePlayer(p)
 }
 

--- a/backend/internal/team/repository.go
+++ b/backend/internal/team/repository.go
@@ -64,7 +64,7 @@ func (r *repository) GetTeamByID(id int) (*TeamCard, error) {
 
 func (r *repository) GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error) {
 	query := `
-        SELECT p.id, p.full_name, p.position, p.photo_url, t.name
+        SELECT p.id, p.uid, p.full_name, p.position, p.photo_url, t.name
         FROM players p
         JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
         JOIN teams t ON t.id = pth.team_id
@@ -79,7 +79,7 @@ func (r *repository) GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error
 	result := []player.PlayerShort{}
 	for rows.Next() {
 		var p player.PlayerShort
-		if err := rows.Scan(&p.ID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
+		if err := rows.Scan(&p.ID, &p.UID, &p.FullName, &p.Position, &p.Photo_URL, &p.Team); err != nil {
 			return nil, err
 		}
 		result = append(result, p)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,191 +1,261 @@
-import React, { useEffect, useState } from 'react'
-import { BrowserRouter as Router, Routes, Route, Link, useParams } from 'react-router-dom'
+import React, { useEffect, useState } from "react";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Link,
+  useParams,
+} from "react-router-dom";
 
-const API_URL = "http://localhost:8080"
+const API_URL = "http://localhost:8080";
 
 function PlayerList() {
-  const [players, setPlayers] = useState([])
-  const [teamMap, setTeamMap] = useState({})
-  const [search, setSearch] = useState("")
+  const [players, setPlayers] = useState([]);
+  const [teamMap, setTeamMap] = useState({});
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     fetch(`${API_URL}/players`)
-      .then(res => res.json())
-      .then(data => setPlayers(data))
+      .then((res) => res.json())
+      .then((data) => setPlayers(data));
     fetch(`${API_URL}/teams`)
-      .then(res => res.json())
-      .then(data => {
-        const map = {}
-        data.forEach(t => { map[t.name] = t.id })
-        setTeamMap(map)
-      })
-  }, [])
+      .then((res) => res.json())
+      .then((data) => {
+        const map = {};
+        data.forEach((t) => {
+          map[t.name] = t.id;
+        });
+        setTeamMap(map);
+      });
+  }, []);
 
   return (
     <div className="p-6">
-      <h1 className="text-4xl font-bold mb-6 text-center text-blue-800">Футбольная Лига</h1>
+      <h1 className="text-4xl font-bold mb-6 text-center text-blue-800">
+        Футбольная Лига
+      </h1>
       <input
         type="text"
         placeholder="Поиск по имени"
         value={search}
-        onChange={e => setSearch(e.target.value)}
+        onChange={(e) => setSearch(e.target.value)}
         className="mb-6 p-2 border rounded w-full sm:w-1/2 mx-auto block"
       />
       <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
         {players
-          .filter(p => p.full_name.toLowerCase().includes(search.toLowerCase()))
-          .map(p => (
-          <Link to={`/players/${p.id}`} key={p.id}>
-            <div className="bg-white shadow-md border border-gray-200 rounded-xl p-4 hover:shadow-xl transition">
-              <div className="flex items-center gap-4">
-                <div className="border-4 border-blue-300 rounded-full overflow-hidden w-20 h-20">
-                  <img
-                    src={p.photo_url || "https://via.placeholder.com/80x80?text=?"}
-                    alt={p.full_name}
-                    className="object-cover w-full h-full"
-                  />
-                </div>
-                <div>
-                  <div className="font-semibold text-lg text-blue-700">{p.full_name}</div>
-                  <div className="text-gray-600 text-sm">
-                    {p.position} — {teamMap[p.team]
-                      ? <Link to={`/teams/${teamMap[p.team]}`} className="text-blue-600 hover:underline">{p.team}</Link>
-                      : p.team}
+          .filter((p) =>
+            p.full_name.toLowerCase().includes(search.toLowerCase()),
+          )
+          .map((p) => (
+            <Link to={`/players/${p.uid}`} key={p.uid}>
+              <div className="bg-white shadow-md border border-gray-200 rounded-xl p-4 hover:shadow-xl transition">
+                <div className="flex items-center gap-4">
+                  <div className="border-4 border-blue-300 rounded-full overflow-hidden w-20 h-20">
+                    <img
+                      src={
+                        p.photo_url ||
+                        "https://via.placeholder.com/80x80?text=?"
+                      }
+                      alt={p.full_name}
+                      className="object-cover w-full h-full"
+                    />
+                  </div>
+                  <div>
+                    <div className="font-semibold text-lg text-blue-700">
+                      {p.full_name}
+                    </div>
+                    <div className="text-gray-600 text-sm">
+                      {p.position} —{" "}
+                      {teamMap[p.team] ? (
+                        <Link
+                          to={`/teams/${teamMap[p.team]}`}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {p.team}
+                        </Link>
+                      ) : (
+                        p.team
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))}
       </div>
     </div>
-  )
+  );
 }
 
 function PlayerCard() {
-  const { id } = useParams()
-  const [player, setPlayer] = useState(null)
-  const [teamMap, setTeamMap] = useState({})
+  const { uid } = useParams();
+  const [player, setPlayer] = useState(null);
+  const [teamMap, setTeamMap] = useState({});
 
   useEffect(() => {
-    fetch(`${API_URL}/players/${id}`)
-      .then(res => res.json())
-      .then(data => setPlayer(data))
-  }, [id])
+    fetch(`${API_URL}/players/${uid}`)
+      .then((res) => res.json())
+      .then((data) => setPlayer(data));
+    }, [uid]);
 
   useEffect(() => {
     fetch(`${API_URL}/teams`)
-      .then(res => res.json())
-      .then(data => {
-        const map = {}
-        data.forEach(t => {
-          map[t.name] = t.id
-        })
-        setTeamMap(map)
-      })
-  }, [])
+      .then((res) => res.json())
+      .then((data) => {
+        const map = {};
+        data.forEach((t) => {
+          map[t.name] = t.id;
+        });
+        setTeamMap(map);
+      });
+  }, []);
 
-  if (!player) return <div className="p-6">Загрузка...</div>
+  if (!player) return <div className="p-6">Загрузка...</div>;
 
   return (
     <div className="max-w-2xl mx-auto p-6">
       <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-200">
         <img
-          src={player.photo_url || "https://via.placeholder.com/400x200?text=ФОТО+ИГРОКА"}
+          src={
+            player.photo_url ||
+            "https://via.placeholder.com/400x200?text=ФОТО+ИГРОКА"
+          }
           alt={player.full_name}
           className="w-full h-48 object-cover rounded-md mb-4 border"
         />
-        <h1 className="text-2xl font-bold text-blue-800 mb-1">{player.full_name}</h1>
+        <h1 className="text-2xl font-bold text-blue-800 mb-1">
+          {player.full_name}
+        </h1>
         <div className="text-gray-600 text-lg mb-2">{player.position}</div>
         <div className="text-blue-600 font-semibold mb-4">
-          {teamMap[player.team]
-            ? <Link to={`/teams/${teamMap[player.team]}`} className="hover:underline">{player.team}</Link>
-            : player.team}
+          {teamMap[player.team] ? (
+            <Link
+              to={`/teams/${teamMap[player.team]}`}
+              className="hover:underline"
+            >
+              {player.team}
+            </Link>
+          ) : (
+            player.team
+          )}
         </div>
 
         <div className="grid grid-cols-2 gap-4 text-sm text-gray-800">
-          <div><b>Голы:</b> {player.stats.goals}</div>
-          <div><b>Передачи:</b> {player.stats.assists}</div>
-          <div><b>ЖК:</b> {player.stats.yellow_cards}</div>
-          <div><b>КК:</b> {player.stats.red_cards}</div>
+          <div>
+            <b>Голы:</b> {player.stats.goals}
+          </div>
+          <div>
+            <b>Пасы:</b> {player.stats.passes}
+          </div>
+          <div>
+            <b>ЖК:</b> {player.stats.yellow_cards}
+          </div>
+          <div>
+            <b>КК:</b> {player.stats.red_cards}
+          </div>
+          <div>
+            <b>Победы:</b> {player.stats.wins}
+          </div>
+          <div>
+            <b>Поражения:</b> {player.stats.losses}
+          </div>
         </div>
 
-        <Link to="/players" className="block mt-6 text-blue-500 hover:underline">← Назад к списку</Link>
+        <Link
+          to="/players"
+          className="block mt-6 text-blue-500 hover:underline"
+        >
+          ← Назад к списку
+        </Link>
       </div>
     </div>
-  )
+  );
 }
 
 function TeamList() {
-  const [teams, setTeams] = useState([])
+  const [teams, setTeams] = useState([]);
 
   useEffect(() => {
     fetch(`${API_URL}/teams`)
-      .then(res => res.json())
-      .then(data => setTeams(data))
-  }, [])
+      .then((res) => res.json())
+      .then((data) => setTeams(data));
+  }, []);
 
   return (
     <div className="p-6">
-      <h1 className="text-4xl font-bold mb-6 text-center text-blue-800">Команды</h1>
+      <h1 className="text-4xl font-bold mb-6 text-center text-blue-800">
+        Команды
+      </h1>
       <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
-        {teams.map(t => (
+        {teams.map((t) => (
           <Link to={`/teams/${t.id}`} key={t.id}>
             <div className="bg-white shadow-md border border-gray-200 rounded-xl p-4 hover:shadow-xl transition">
               <div className="flex items-center gap-4">
                 <div className="border-4 border-blue-300 rounded-full overflow-hidden w-20 h-20">
                   <img
-                    src={t.logo_url || "https://via.placeholder.com/80x80?text=?"}
+                    src={
+                      t.logo_url || "https://via.placeholder.com/80x80?text=?"
+                    }
                     alt={t.name}
                     className="object-cover w-full h-full"
                   />
                 </div>
-                <div className="font-semibold text-lg text-blue-700">{t.name}</div>
+                <div className="font-semibold text-lg text-blue-700">
+                  {t.name}
+                </div>
               </div>
             </div>
           </Link>
         ))}
       </div>
     </div>
-  )
+  );
 }
 
 function TeamCard() {
-  const { id } = useParams()
-  const [team, setTeam] = useState(null)
+  const { id } = useParams();
+  const [team, setTeam] = useState(null);
 
   useEffect(() => {
     fetch(`${API_URL}/teams/${id}`)
-      .then(res => res.json())
-      .then(data => setTeam(data))
-  }, [id])
+      .then((res) => res.json())
+      .then((data) => setTeam(data));
+  }, [id]);
 
-  if (!team) return <div className="p-6">Загрузка...</div>
+  if (!team) return <div className="p-6">Загрузка...</div>;
 
   return (
     <div className="max-w-2xl mx-auto p-6">
       <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-200">
         <img
-          src={team.logo_url || "https://via.placeholder.com/400x200?text=ЛОГО+КОМАНДЫ"}
+          src={
+            team.logo_url ||
+            "https://via.placeholder.com/400x200?text=ЛОГО+КОМАНДЫ"
+          }
           alt={team.name}
           className="w-full h-48 object-cover rounded-md mb-4 border"
         />
         <h1 className="text-2xl font-bold text-blue-800 mb-4">{team.name}</h1>
 
         <div className="grid gap-6 grid-cols-1 sm:grid-cols-2">
-          {team.players.map(p => (
-            <Link to={`/players/${p.id}`} key={p.id}>
+        {team.players.map((p) => (
+            <Link to={`/players/${p.uid}`} key={p.uid}>
               <div className="bg-white shadow-md border border-gray-200 rounded-xl p-4 hover:shadow-xl transition">
                 <div className="flex items-center gap-4">
                   <div className="border-4 border-blue-300 rounded-full overflow-hidden w-20 h-20">
                     <img
-                      src={p.photo_url || "https://via.placeholder.com/80x80?text=?"}
+                      src={
+                        p.photo_url ||
+                        "https://via.placeholder.com/80x80?text=?"
+                      }
                       alt={p.full_name}
                       className="object-cover w-full h-full"
                     />
                   </div>
                   <div>
-                    <div className="font-semibold text-lg text-blue-700">{p.full_name}</div>
+                    <div className="font-semibold text-lg text-blue-700">
+                      {p.full_name}
+                    </div>
                     <div className="text-gray-600 text-sm">{p.position}</div>
                   </div>
                 </div>
@@ -194,106 +264,128 @@ function TeamCard() {
           ))}
         </div>
 
-        <Link to="/teams" className="block mt-6 text-blue-500 hover:underline">← Назад к списку команд</Link>
+        <Link to="/teams" className="block mt-6 text-blue-500 hover:underline">
+          ← Назад к списку команд
+        </Link>
       </div>
     </div>
-  )
+  );
 }
 
 function MatchList() {
-  const [matches, setMatches] = useState([])
-  const [teamMap, setTeamMap] = useState({})
+  const [matches, setMatches] = useState([]);
+  const [teamMap, setTeamMap] = useState({});
 
   useEffect(() => {
     fetch(`${API_URL}/matches`)
-      .then(res => res.json())
-      .then(data => setMatches(data))
+      .then((res) => res.json())
+      .then((data) => setMatches(data));
     fetch(`${API_URL}/teams`)
-      .then(res => res.json())
-      .then(data => {
-        const map = {}
-        data.forEach(t => {
-          map[t.id] = t.name
-        })
-        setTeamMap(map)
-      })
-  }, [])
+      .then((res) => res.json())
+      .then((data) => {
+        const map = {};
+        data.forEach((t) => {
+          map[t.id] = t.name;
+        });
+        setTeamMap(map);
+      });
+  }, []);
 
   return (
     <div className="p-6">
-      <h1 className="text-4xl font-bold mb-6 text-center text-blue-800">Матчи</h1>
+      <h1 className="text-4xl font-bold mb-6 text-center text-blue-800">
+        Матчи
+      </h1>
       <div className="space-y-4">
-        {matches.map(m => (
-          <div key={m.id} className="bg-white shadow-md border border-gray-200 rounded-xl p-4">
+        {matches.map((m) => (
+          <div
+            key={m.id}
+            className="bg-white shadow-md border border-gray-200 rounded-xl p-4"
+          >
             <div className="flex justify-between items-center mb-2">
-              <Link to={`/teams/${m.home_team_id}`} className="text-blue-700 hover:underline">
+              <Link
+                to={`/teams/${m.home_team_id}`}
+                className="text-blue-700 hover:underline"
+              >
                 {teamMap[m.home_team_id] || m.home_team_id}
               </Link>
               <div className="font-bold text-blue-800">
                 {m.home_score} : {m.away_score}
               </div>
-              <Link to={`/teams/${m.away_team_id}`} className="text-blue-700 hover:underline">
+              <Link
+                to={`/teams/${m.away_team_id}`}
+                className="text-blue-700 hover:underline"
+              >
                 {teamMap[m.away_team_id] || m.away_team_id}
               </Link>
             </div>
             <div className="text-sm text-gray-600 mb-2">{m.date}</div>
-            <Link to={`/matches/${m.id}`} className="text-blue-500 hover:underline">
+            <Link
+              to={`/matches/${m.id}`}
+              className="text-blue-500 hover:underline"
+            >
               Подробнее
             </Link>
           </div>
         ))}
       </div>
     </div>
-  )
+  );
 }
 
 function MatchCard() {
-  const { id } = useParams()
-  const [match, setMatch] = useState(null)
-  const [teamMap, setTeamMap] = useState({})
-  const [playerMap, setPlayerMap] = useState({})
+  const { id } = useParams();
+  const [match, setMatch] = useState(null);
+  const [teamMap, setTeamMap] = useState({});
+  const [playerMap, setPlayerMap] = useState({});
 
   useEffect(() => {
     fetch(`${API_URL}/matches/${id}`)
-      .then(res => res.json())
-      .then(data => setMatch(data))
-  }, [id])
+      .then((res) => res.json())
+      .then((data) => setMatch(data));
+  }, [id]);
 
   useEffect(() => {
     fetch(`${API_URL}/teams`)
-      .then(res => res.json())
-      .then(data => {
-        const map = {}
-        data.forEach(t => {
-          map[t.id] = t.name
-        })
-        setTeamMap(map)
-      })
+      .then((res) => res.json())
+      .then((data) => {
+        const map = {};
+        data.forEach((t) => {
+          map[t.id] = t.name;
+        });
+        setTeamMap(map);
+      });
     fetch(`${API_URL}/players`)
-      .then(res => res.json())
-      .then(data => {
-        const map = {}
-        data.forEach(p => {
-          map[p.id] = p.full_name
-        })
-        setPlayerMap(map)
-      })
-  }, [])
+      .then((res) => res.json())
+      .then((data) => {
+        const map = {};
+        data.forEach((p) => {
+          map[p.id] = { name: p.full_name, uid: p.uid };
+        });
+        setPlayerMap(map);
+      });
+  }, []);
 
-  if (!match) return <div className="p-6">Загрузка...</div>
+  if (!match) return <div className="p-6">Загрузка...</div>;
 
   return (
     <div className="max-w-3xl mx-auto p-6">
       <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-200">
         <div className="text-center mb-4">
           <div className="flex justify-between text-xl font-semibold text-blue-800">
-            <Link to={`/teams/${match.home_team_id}`} className="hover:underline">
+            <Link
+              to={`/teams/${match.home_team_id}`}
+              className="hover:underline"
+            >
               {teamMap[match.home_team_id] || match.home_team_id}
             </Link>
             <div>
               {match.home_score} : {match.away_score}
             </div>
-            <Link to={`/teams/${match.away_team_id}`} className="hover:underline">
+            <Link
+              to={`/teams/${match.away_team_id}`}
+              className="hover:underline"
+            >
               {teamMap[match.away_team_id] || match.away_team_id}
             </Link>
           </div>
@@ -306,26 +398,32 @@ function MatchCard() {
               <th className="py-2">Игрок</th>
               <th className="py-2">Команда</th>
               <th className="py-2">Голы</th>
-              <th className="py-2">Передачи</th>
+              <th className="py-2">Пасы</th>
               <th className="py-2">ЖК</th>
               <th className="py-2">КК</th>
             </tr>
           </thead>
           <tbody>
-            {match.participants.map(p => (
+            {match.participants.map((p) => (
               <tr key={p.player_id} className="border-b">
                 <td className="py-2">
-                  <Link to={`/players/${p.player_id}`} className="text-blue-600 hover:underline">
-                    {playerMap[p.player_id] || p.player_id}
+                  <Link
+                    to={`/players/${playerMap[p.player_id]?.uid || ""}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {playerMap[p.player_id]?.name || p.player_id}
                   </Link>
                 </td>
                 <td className="py-2">
-                  <Link to={`/teams/${p.team_id}`} className="text-blue-600 hover:underline">
+                  <Link
+                    to={`/teams/${p.team_id}`}
+                    className="text-blue-600 hover:underline"
+                  >
                     {teamMap[p.team_id] || p.team_id}
                   </Link>
                 </td>
                 <td className="py-2">{p.goals}</td>
-                <td className="py-2">{p.assists}</td>
+                <td className="py-2">{p.passes}</td>
                 <td className="py-2">{p.yellow_cards}</td>
                 <td className="py-2">{p.red_cards}</td>
               </tr>
@@ -333,12 +431,15 @@ function MatchCard() {
           </tbody>
         </table>
 
-        <Link to="/matches" className="block mt-6 text-blue-500 hover:underline">
+        <Link
+          to="/matches"
+          className="block mt-6 text-blue-500 hover:underline"
+        >
           ← Назад к списку матчей
         </Link>
       </div>
     </div>
-  )
+  );
 }
 
 export default function App() {
@@ -347,12 +448,12 @@ export default function App() {
       <Routes>
         <Route path="/" element={<PlayerList />} />
         <Route path="/players" element={<PlayerList />} />
-        <Route path="/players/:id" element={<PlayerCard />} />
+        <Route path="/players/:uid" element={<PlayerCard />} />
         <Route path="/teams" element={<TeamList />} />
         <Route path="/teams/:id" element={<TeamCard />} />
         <Route path="/matches" element={<MatchList />} />
         <Route path="/matches/:id" element={<MatchCard />} />
       </Routes>
     </Router>
-  )
+  );
 }

--- a/schema.sql
+++ b/schema.sql
@@ -44,9 +44,14 @@ CREATE TABLE team_league_season (
     UNIQUE(team_id, season_id)
 );
 
+-- ===============================================
+-- Схема информации об игроках
+-- ===============================================
+
 -- Игроки
 CREATE TABLE players (
     id SERIAL PRIMARY KEY,
+    uid TEXT NOT NULL UNIQUE,
     full_name TEXT NOT NULL,
     position TEXT NOT NULL,
     photo_url TEXT
@@ -60,6 +65,10 @@ CREATE TABLE player_team_history (
     start_date DATE NOT NULL,
     end_date DATE
 );
+
+-- ===============================================
+-- Схема информации о матчах
+-- ===============================================
 
 -- Туры
 CREATE TABLE rounds (
@@ -92,12 +101,12 @@ CREATE TABLE match_participation (
     CONSTRAINT uq_match_player UNIQUE(match_id, player_id)
 );
 
--- Статистика игрока в конкретном матче (только Г, П, Ж, К)
+-- Статистика игрока в конкретном матче (Г, Пас, ЖК, КК)
 CREATE TABLE player_stats (
     id SERIAL PRIMARY KEY,
     match_participation_id INT NOT NULL REFERENCES match_participation(id),
     goals INT DEFAULT 0,
-    assists INT DEFAULT 0,
+    passes INT DEFAULT 0,
     yellow_cards INT DEFAULT 0,
     red_cards INT DEFAULT 0,
     CONSTRAINT uq_stats_participation UNIQUE(match_participation_id)
@@ -111,12 +120,27 @@ CREATE TABLE player_stats (
 CREATE OR REPLACE VIEW v_player_total_stats AS
 SELECT
     mp.player_id,
-    SUM(ps.goals) AS total_goals,
-    SUM(ps.assists) AS total_assists,
-    SUM(ps.yellow_cards) AS total_yellow,
-    SUM(ps.red_cards) AS total_red
-FROM player_stats ps
-JOIN match_participation mp ON mp.id = ps.match_participation_id
+    COALESCE(SUM(ps.goals), 0) AS total_goals,
+    COALESCE(SUM(ps.passes), 0) AS total_passes,
+    COALESCE(SUM(ps.yellow_cards), 0) AS total_yellow,
+    COALESCE(SUM(ps.red_cards), 0) AS total_red,
+    SUM(
+        CASE
+            WHEN (mp.team_id = m.home_team_id AND m.home_score > m.away_score)
+              OR (mp.team_id = m.away_team_id AND m.away_score > m.home_score)
+            THEN 1 ELSE 0
+        END
+    ) AS total_wins,
+    SUM(
+        CASE
+            WHEN (mp.team_id = m.home_team_id AND m.home_score < m.away_score)
+              OR (mp.team_id = m.away_team_id AND m.away_score < m.home_score)
+            THEN 1 ELSE 0
+        END
+    ) AS total_losses
+FROM match_participation mp
+LEFT JOIN player_stats ps ON mp.id = ps.match_participation_id
+JOIN matches m ON m.id = mp.match_id
 GROUP BY mp.player_id;
 
 -- ===============================================


### PR DESCRIPTION
## Summary
- add unique `uid` column for players and expose it in API models
- fetch player cards by string UID and return UID when creating players
- update frontend to route players using `/players/:uid`

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9bfef2bcc832a88653c0c7cafa0c7