### PR TITLE
Handle null player photos in queries

### DIFF
--- a/backend/internal/player/repository.go
+++ b/backend/internal/player/repository.go
@@ -33,7 +33,7 @@ func (r *repository) GetPlayerCardByUID(uid string) (*PlayerCard, error) {
         p.uid,
         p.full_name,
         p.position,
-        p.photo_url,
+        COALESCE(p.photo_url, '') AS photo_url,
         t.name AS team_name,
         COALESCE(v.total_goals, 0),
         COALESCE(v.total_passes, 0),
@@ -70,7 +70,7 @@ func (r *repository) GetPlayerCardByName(name string) (*PlayerCard, error) {
         p.uid,
         p.full_name,
         p.position,
-        p.photo_url,
+        COALESCE(p.photo_url, '') AS photo_url,
         t.name AS team_name,
         COALESCE(v.total_goals, 0),
         COALESCE(v.total_passes, 0),
@@ -107,7 +107,7 @@ func (r *repository) GetAllPlayers() ([]PlayerShort, error) {
         p.uid,
         p.full_name,
         p.position,
-        p.photo_url,
+        COALESCE(p.photo_url, '') AS photo_url,
         t.name AS team_name
     FROM players p
     JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
@@ -139,7 +139,7 @@ func (r *repository) SearchPlayers(name string, leagueID, teamID int) ([]PlayerS
         p.uid,
         p.full_name,
         p.position,
-        p.photo_url,
+        COALESCE(p.photo_url, '') AS photo_url,
         t.name AS team_name
     FROM players p
     JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL

--- a/backend/internal/team/repository.go
+++ b/backend/internal/team/repository.go
@@ -64,7 +64,7 @@ func (r *repository) GetTeamByID(id int) (*TeamCard, error) {
 
 func (r *repository) GetPlayersByTeamID(teamID int) ([]player.PlayerShort, error) {
 	query := `
-        SELECT p.id, p.uid, p.full_name, p.position, p.photo_url, t.name
+        SELECT p.id, p.uid, p.full_name, p.position, COALESCE(p.photo_url, '') AS photo_url, t.name
         FROM players p
         JOIN player_team_history pth ON p.id = pth.player_id AND pth.end_date IS NULL
         JOIN teams t ON t.id = pth.team_id


### PR DESCRIPTION
## Summary
- Avoid NULL scan errors by wrapping photo_url with COALESCE in player and team queries

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a9d2648aa8832aa3f99a4751839922